### PR TITLE
Enable define targetSchema field

### DIFF
--- a/lib/json_world/link_definition.rb
+++ b/lib/json_world/link_definition.rb
@@ -22,6 +22,7 @@ module JsonWorld
         method: http_method,
         rel: rel,
         schema: schema,
+        targetSchema: target_schema,
         title: title,
       }.reject do |_key, value|
         value.nil? || value.empty?
@@ -62,6 +63,16 @@ module JsonWorld
         JsonWorld::PropertyDefinition.new(
           properties: @options[:parameters],
           property_name: :schema,
+        ).as_json_schema
+      end
+    end
+
+    # @return [Hash{Symbol => Object}, nil]
+    def target_schema
+      if @options[:target_schema]
+        JsonWorld::PropertyDefinition.new(
+          properties: @options[:target_schema],
+          property_name: :targetSchema,
         ).as_json_schema
       end
     end

--- a/spec/json_world/dsl_spec.rb
+++ b/spec/json_world/dsl_spec.rb
@@ -96,6 +96,20 @@ RSpec.describe JsonWorld::DSL do
       )
 
       link(
+        :get_user_name,
+        description: "Get a single user name",
+        path: "/users/:user_id/name",
+        rel: "self",
+        target_schema: {
+          name: {
+            description: "The name of this user",
+            example: "alice",
+            type: String,
+          },
+        },
+      )
+
+      link(
         :create_user,
         description: "Create a new user",
         method: "POST",
@@ -148,6 +162,25 @@ RSpec.describe JsonWorld::DSL do
             method: "GET",
             rel: "self",
             title: "get_user",
+          },
+          {
+            description: "Get a single user name",
+            href: "/users/:user_id/name",
+            method: "GET",
+            rel: "self",
+            targetSchema: {
+              properties: {
+                name: {
+                  description: "The name of this user",
+                  example: "alice",
+                  type: "string",
+                },
+              },
+              required: [
+                :name,
+              ],
+            },
+            title: "get_user_name",
           },
           {
             description: "Create a new user",


### PR DESCRIPTION
This gem is very useful and powerful solution for JSON Schema.
I am always grateful for your solutions.

And this time, I would like to enable define to "targetSchema" field.
I hope you are able to merge, if you think to goodness!

Thanks.
