### PR TITLE
Use Hash instead of keyword arguments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in json_world.gemspec
 gemspec
+
+gem "rake", "~> 10.0"
+gem "rspec", "3.2.0"

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in json_world.gemspec
 gemspec
 
-gem "rake", "~> 10.0"
-gem "rspec", "3.2.0"
+gem "rake"
+gem "rspec"

--- a/json_world.gemspec
+++ b/json_world.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
-  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "3.2.0"
 end

--- a/json_world.gemspec
+++ b/json_world.gemspec
@@ -15,6 +15,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "3.2.0"
 end

--- a/lib/json_world/dsl.rb
+++ b/lib/json_world/dsl.rb
@@ -53,7 +53,7 @@ module JsonWorld
       def link(link_name, options = {})
         link_definitions << JsonWorld::LinkDefinition.new(
           link_name: link_name,
-          **options.merge(
+          options.merge(
             parent: self,
           ),
         )
@@ -69,7 +69,7 @@ module JsonWorld
       def property(property_name, options = {})
         property_definitions << JsonWorld::PropertyDefinition.new(
           property_name: property_name,
-          **options.merge(
+          options.merge(
             parent: self,
           )
         )

--- a/lib/json_world/link_definition.rb
+++ b/lib/json_world/link_definition.rb
@@ -7,7 +7,7 @@ module JsonWorld
 
     # @param [Symbol] link_name
     # @param [Hash{Symbol => Object}] options
-    def initialize(link_name: nil, **options)
+    def initialize(link_name: nil, options)
       @options = options
       @link_name = link_name
     end

--- a/lib/json_world/property_definition.rb
+++ b/lib/json_world/property_definition.rb
@@ -7,7 +7,7 @@ module JsonWorld
 
     # @param [Symbol, nil] property_name Note that unnamed property can be passed
     # @param [Hash{Symbol => Object}] options
-    def initialize(property_name: nil, **options)
+    def initialize(property_name: nil, options)
       @options = options
       @property_name = property_name
     end
@@ -83,7 +83,7 @@ module JsonWorld
     # @return [Array<Hash>, nil]
     def items_as_json_schema
       if @options[:items]
-        JsonWorld::PropertyDefinition.new(**@options[:items]).as_json_schema
+        JsonWorld::PropertyDefinition.new(@options[:items]).as_json_schema
       end
     end
 
@@ -113,7 +113,7 @@ module JsonWorld
         @options[:properties].map do |property_name, options|
           JsonWorld::PropertyDefinition.new(
             property_name: property_name,
-            **options
+            options
           )
         end
       end


### PR DESCRIPTION
Since this value does not have a specific set of keys, but has variable keys that can change depending on the situation, I thought that keyword argument was not appropriate.